### PR TITLE
Comment out Vagrant Push strategy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,10 +57,10 @@ Vagrant.configure(2) do |config|
   # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
   # such as FTP and Heroku are also available. See the documentation at
   # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  config.push.define 'atlas' do |push|
-    push.app = 'DanBarreto/twseleniumworkshop'
-    push.vcs = true
-  end
+  # config.push.define 'atlas' do |push|
+    # push.app = 'DanBarreto/twseleniumworkshop'
+    # push.vcs = true
+  # end
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the


### PR DESCRIPTION
People just want to use the vagrant image, we don't need them signup to HashCorp and create their Atlas account.
